### PR TITLE
Plugin development pod f

### DIFF
--- a/PersistenceMigrationsSample/app/build.gradle
+++ b/PersistenceMigrationsSample/app/build.gradle
@@ -84,6 +84,7 @@ android {
 }
 
 dependencies {
+    implementation deps.arch_core.runtime
     implementation deps.app_compat
     implementation deps.material
     implementation deps.room.runtime


### PR DESCRIPTION
… depend on.

Prevent drift between arch.testing and the runtime dependencies.

Fixes #801

Test: in the PersistenceMigrationsSample, ran ./gradlew cC